### PR TITLE
add example:docker easy-simple-network-default-driver

### DIFF
--- a/examples/docker/easy-simple-network-default-driver/main.tf
+++ b/examples/docker/easy-simple-network-default-driver/main.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_network" "bridge_network" {
+  name = "bridge_network"
+}

--- a/examples/docker/easy-simple-network-default-driver/main.tf
+++ b/examples/docker/easy-simple-network-default-driver/main.tf
@@ -1,5 +1,5 @@
 # https://github.com/ssbostan/terraform-awesome
 
-resource "docker_network" "bridge_network" {
-  name = "bridge_network"
+resource "docker_network" "simple_network" {
+  name = "simple_network"
 }

--- a/examples/docker/easy-simple-network-default-driver/providers.tf
+++ b/examples/docker/easy-simple-network-default-driver/providers.tf
@@ -1,0 +1,6 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}
+

--- a/examples/docker/easy-simple-network-default-driver/providers.tf
+++ b/examples/docker/easy-simple-network-default-driver/providers.tf
@@ -3,4 +3,3 @@
 provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
-

--- a/examples/docker/easy-simple-network-default-driver/terraform.tf
+++ b/examples/docker/easy-simple-network-default-driver/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request related to task 11 create a new network with default driver `easy-simple-network-default-driver`