### PR TITLE
add example:docker easy-redis-config-mount

### DIFF
--- a/examples/docker/easy-redis-config-mount/main.tf
+++ b/examples/docker/easy-redis-config-mount/main.tf
@@ -1,0 +1,19 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_container" "redis_container" {
+  name     = "redis_container"
+  image    = "redis:latest"
+  command  = ["redis-server", "/usr/local/etc/redis/redis.conf"]
+  ports {
+    internal = 6379
+    external = 6379
+    ip       = "0.0.0.0"
+
+  }
+
+  volumes {
+    host_path      = abspath("redis-config/redis.conf")
+    container_path = "/usr/local/etc/redis/redis.conf"
+  }
+
+}

--- a/examples/docker/easy-redis-config-mount/providers.tf
+++ b/examples/docker/easy-redis-config-mount/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/easy-redis-config-mount/redis-config/redis.conf
+++ b/examples/docker/easy-redis-config-mount/redis-config/redis.conf
@@ -1,0 +1,27 @@
+#requirepass some-long-password
+appendonly yes
+
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all the network interfaces available on the server.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1 ::1
+#
+# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Redis to listen only into
+# the IPv4 loopback interface address (this means Redis will be able to
+# accept connections only from clients running into the same computer it
+# is running).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# JUST COMMENT THE FOLLOWING LINE.*
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# bind 127.0.0.1

--- a/examples/docker/easy-redis-config-mount/terraform.tf
+++ b/examples/docker/easy-redis-config-mount/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
I've completed task number 36: create redis container with custom config file and publish its port `easy-redis-config-mount`