### PR TITLE
add example:docker easy-redis-config-mount

### DIFF
--- a/examples/docker/easy-redis-config-mount/main.tf
+++ b/examples/docker/easy-redis-config-mount/main.tf
@@ -1,0 +1,16 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_container" "redis_container" {
+  name    = "redis_container"
+  image   = "redis:latest"
+  command = ["redis-server", "/usr/local/etc/redis/redis.conf"]
+  ports {
+    internal = 6379
+    external = 6379
+    ip       = "0.0.0.0"
+  }
+  volumes {
+    host_path      = abspath("redis.conf")
+    container_path = "/usr/local/etc/redis/redis.conf"
+  }
+}

--- a/examples/docker/easy-redis-config-mount/providers.tf
+++ b/examples/docker/easy-redis-config-mount/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/easy-redis-config-mount/redis.conf
+++ b/examples/docker/easy-redis-config-mount/redis.conf
@@ -1,0 +1,1 @@
+appendonly yes

--- a/examples/docker/easy-redis-config-mount/terraform.tf
+++ b/examples/docker/easy-redis-config-mount/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
I completed task 36: create redis container with custom config file and publish its port `easy-redis-config-mount`