### PR TITLE
add example:docker easy-container-add-host

### DIFF
--- a/examples/docker/easy-container-add-host/main.tf
+++ b/examples/docker/easy-container-add-host/main.tf
@@ -1,0 +1,18 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_image" "nginx_image" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "nginx_container" {
+  name  = "nginx_container"
+  image = docker_image.nginx_image.name
+  host {
+    host = "yourdomain.com"
+    ip   = "127.0.0.1"
+  }
+  host {
+    host = "cloudflare"
+    ip   = "1.1.1.1"
+  }
+}

--- a/examples/docker/easy-container-add-host/providers.tf
+++ b/examples/docker/easy-container-add-host/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/easy-container-add-host/terraform.tf
+++ b/examples/docker/easy-container-add-host/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION


This pull request related to task 26 create a new container with some /etc/hosts entries `easy-container-add-host`