### PR TITLE
add example:docker moderate-mysql-phpmyadmin-stack

### DIFF
--- a/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
+++ b/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
@@ -1,0 +1,38 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_network" "backend" {
+  name     = "backend"
+  internal = true
+}
+
+resource "docker_network" "frontend" {
+  name = "frontend"
+}
+
+resource "docker_container" "mysql_container" {
+  name  = "mysql"
+  image = "mysql:latest"
+  env   = ["MYSQL_ROOT_PASSWORD=test", "MYSQL_DATABASE=test", "MYSQL_USER=test", "MYSQL_PASSWORD=test"]
+  networks_advanced {
+    name    = docker_network.backend.name
+    aliases = ["backend"]
+  }
+}
+
+resource "docker_container" "phpmyadmin_container" {
+  name  = "phpmyadmin"
+  image = "phpmyadmin/phpmyadmin"
+  env   = ["PMA_ARBITRARY=1", "PMA_HOST=${docker_container.mysql_container.name}", "PMA_USER=test", "PMA_PASSWORD=test"]
+  ports {
+    internal = 80
+    external = 8080
+  }
+  networks_advanced {
+    name    = docker_network.backend.name
+    aliases = ["backend"]
+  }
+  networks_advanced {
+    name    = docker_network.frontend.name
+    aliases = ["frontend"]
+  }
+}

--- a/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
+++ b/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
@@ -17,6 +17,11 @@ resource "docker_container" "mysql_container" {
     name    = docker_network.backend.name
     aliases = ["backend"]
   }
+  volumes {
+    container_path = "/var/lib/mysql"
+    #    volume_name    = docker_volume.mysql_volume.name
+    host_path = "/opt/mysql"
+  }
 }
 
 resource "docker_container" "phpmyadmin_container" {

--- a/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
+++ b/examples/docker/moderate-mysql-phpmyadmin-stack/main.tf
@@ -1,43 +1,53 @@
 # https://github.com/ssbostan/terraform-awesome
 
 resource "docker_network" "backend" {
-  name     = "backend"
-  internal = true
+  name = "backend"
 }
 
 resource "docker_network" "frontend" {
   name = "frontend"
 }
 
+resource "docker_volume" "mysql_data" {
+  name   = "mysql_data"
+  driver = "local"
+}
+
 resource "docker_container" "mysql_container" {
   name  = "mysql"
   image = "mysql:latest"
-  env   = ["MYSQL_ROOT_PASSWORD=test", "MYSQL_DATABASE=test", "MYSQL_USER=test", "MYSQL_PASSWORD=test"]
+  env = [
+    "MYSQL_ROOT_PASSWORD=root",
+    "MYSQL_DATABASE=test",
+    "MYSQL_USER=test",
+    "MYSQL_PASSWORD=test"
+  ]
   networks_advanced {
-    name    = docker_network.backend.name
-    aliases = ["backend"]
+    name = docker_network.backend.name
   }
   volumes {
+    volume_name    = docker_volume.mysql_data.name
     container_path = "/var/lib/mysql"
-    #    volume_name    = docker_volume.mysql_volume.name
-    host_path = "/opt/mysql"
   }
 }
 
 resource "docker_container" "phpmyadmin_container" {
   name  = "phpmyadmin"
-  image = "phpmyadmin/phpmyadmin"
-  env   = ["PMA_ARBITRARY=1", "PMA_HOST=${docker_container.mysql_container.name}", "PMA_USER=test", "PMA_PASSWORD=test"]
+  image = "phpmyadmin/phpmyadmin:latest"
+  env = [
+    "PMA_ARBITRARY=1",
+    "PMA_HOST=${docker_container.mysql_container.name}",
+    "PMA_USER=test",
+    "PMA_PASSWORD=test"
+  ]
   ports {
     internal = 80
     external = 8080
   }
   networks_advanced {
-    name    = docker_network.backend.name
-    aliases = ["backend"]
+    name = docker_network.backend.name
   }
   networks_advanced {
-    name    = docker_network.frontend.name
-    aliases = ["frontend"]
+    name = docker_network.frontend.name
   }
 }

--- a/examples/docker/moderate-mysql-phpmyadmin-stack/providers.tf
+++ b/examples/docker/moderate-mysql-phpmyadmin-stack/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/moderate-mysql-phpmyadmin-stack/terraform.tf
+++ b/examples/docker/moderate-mysql-phpmyadmin-stack/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
I completed task 39: create MySQL and PhpMyAdmin containers and config them moderate-mysql-phpmyadmin-stack

volumes binding and using different networks is also taken into account