### PR TITLE
add example:docker easy-container-upload-data

### DIFF
--- a/examples/docker/easy-container-upload-data/file
+++ b/examples/docker/easy-container-upload-data/file
@@ -1,0 +1,2 @@
+Content Of File
+

--- a/examples/docker/easy-container-upload-data/main.tf
+++ b/examples/docker/easy-container-upload-data/main.tf
@@ -1,0 +1,17 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_image" "nginx_image" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "nginx_container" {
+  name  = "nginx_container"
+  image = docker_image.nginx_image.name
+  upload{
+    file = "/data/file"
+    source = "file"
+    
+  }
+
+}
+

--- a/examples/docker/easy-container-upload-data/providers.tf
+++ b/examples/docker/easy-container-upload-data/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/easy-container-upload-data/terraform.tf
+++ b/examples/docker/easy-container-upload-data/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request related to task 16 create a new container and upload data to it `easy-container-upload-data`

