### PR TITLE
add example:docker moderate-custom-network-bridge-driver

### DIFF
--- a/examples/docker/moderate-custom-network-bridge-driver/main.tf
+++ b/examples/docker/moderate-custom-network-bridge-driver/main.tf
@@ -1,7 +1,8 @@
 # https://github.com/ssbostan/terraform-awesome
 
 resource "docker_network" "custom_network" {
-  name = "custom_network"
+  name   = "custom_network"
+  driver = "bridge"
   ipam_config {
     ip_range = "172.28.5.0/24"
     subnet   = "172.28.0.0/16"

--- a/examples/docker/moderate-custom-network-bridge-driver/main.tf
+++ b/examples/docker/moderate-custom-network-bridge-driver/main.tf
@@ -1,0 +1,23 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_network" "custom_network" {
+  name = "custom_network"
+  ipam_config {
+    ip_range = "172.28.5.0/24"
+    subnet   = "172.28.0.0/16"
+    gateway  = "172.28.5.254"
+  }
+}
+
+resource "docker_container" "alpine_container" {
+  name  = "alpine_container"
+  image = "alpine:latest"
+  command = [
+    "tail",
+    "-f",
+    "/dev/null"
+  ]
+  networks_advanced {
+    name = docker_network.custom_network.name
+  }
+}

--- a/examples/docker/moderate-custom-network-bridge-driver/providers.tf
+++ b/examples/docker/moderate-custom-network-bridge-driver/providers.tf
@@ -1,0 +1,5 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}

--- a/examples/docker/moderate-custom-network-bridge-driver/terraform.tf
+++ b/examples/docker/moderate-custom-network-bridge-driver/terraform.tf
@@ -1,0 +1,10 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
I've completed task 12: create a new bridge network with custom IP address `moderate-custom-network-bridge-driver`