### PR TITLE
add example:docker moderate-nginx-https-letsencrypt-certificate

### DIFF
--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/letsencrypt.tf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/letsencrypt.tf
@@ -1,0 +1,30 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = tls_private_key.private_key.private_key_pem
+  email_address   = var.email_address
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem = acme_registration.reg.account_key_pem
+  common_name     = var.domain_name
+
+  http_challenge {
+    port = var.challenge_port
+  }
+}
+
+resource "local_file" "nginx_https_tls_key" {
+  filename = "tls.key"
+  content  = acme_certificate.certificate.private_key_pem
+}
+
+resource "local_file" "nginx_https_tls_cert" {
+  filename = "tls.crt"
+  content  = acme_certificate.certificate.certificate_pem
+}
+

--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/main.tf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/main.tf
@@ -1,0 +1,35 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "docker_image" "nginx" {
+  name = "nginx:latest"
+}
+
+resource "docker_container" "awesome_nginx" {
+  image = docker_image.nginx.name
+  name  = "awesome_nginx"
+  volumes {
+    host_path      = abspath("nginx.conf")
+    container_path = "/etc/nginx/nginx.conf"
+  }
+  volumes {
+    host_path      = abspath("tls.crt")
+    container_path = "/etc/nginx/certs/tls.crt"
+  }
+  volumes {
+    host_path      = abspath("tls.key")
+    container_path = "/etc/nginx/certs/tls.key"
+  }
+  ports {
+    internal = "80"
+    external = "80"
+  }
+  ports {
+    internal = "443"
+    external = "443"
+  }
+
+  depends_on = [
+    local_file.nginx_https_tls_key,
+    local_file.nginx_https_tls_cert
+  ]
+}

--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/nginx.conf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/nginx.conf
@@ -1,0 +1,49 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log notice;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    sendfile on;
+    keepalive_timeout 65;
+
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        ssl_certificate /etc/nginx/certs/tls.crt;
+        ssl_certificate_key /etc/nginx/certs/tls.key;
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:le_nginx_SSL:10m;
+        ssl_session_tickets off;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+        ssl_prefer_server_ciphers off;
+        add_header Strict-Transport-Security "max-age=63072000" always;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 127.0.0.1;
+        location / {
+            root /usr/share/nginx/html;
+            index index.html;
+        }
+    }
+}

--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/providers.tf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/providers.tf
@@ -1,0 +1,9 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "docker" {
+  host = "unix:///var/run/docker.sock"
+}
+
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}

--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/terraform.tf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/terraform.tf
@@ -1,0 +1,14 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~>2.16.0"
+    }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~>2.9.0"
+    }
+  }
+}

--- a/examples/docker/moderate-nginx-https-letsencrypt-certificate/variables.tf
+++ b/examples/docker/moderate-nginx-https-letsencrypt-certificate/variables.tf
@@ -1,0 +1,16 @@
+# https://github.com/ssbostan/terraform-awesome
+
+variable "email_address" {
+  description = "This is an email for letsencrypt registration."
+  type = string
+}
+
+variable "domain_name" {
+  description = "Your website domain name."
+  type = string
+}
+
+variable "challenge_port" {
+  type    = number
+  default = 80
+}


### PR DESCRIPTION
add missing task #34 add example:docker `moderate-nginx-https-letsencrypt-certificate` of docker examples