### PR TITLE
add example:kubernetes easy-kubernetes-pod-container-command-args-override

### DIFF
--- a/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/main.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/main.tf
@@ -1,0 +1,20 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "kubernetes_pod" "nginx" {
+  metadata {
+    name      = "nginx"
+    namespace = "default"
+    labels = {
+      "app.kubernetes.io/name"       = "nginx"
+      "app.kubernetes.io/created-by" = "terraform-awesome"
+    }
+  }
+  spec {
+    container {
+      name    = "nginx"
+      image   = "nginx:latest"
+      command = ["/usr/sbin/nginx"]
+      args    = ["-g", "daemon off;"]
+    }
+  }
+}

--- a/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/providers.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/providers.tf
@@ -1,0 +1,6 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "default"
+}

--- a/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/terraform.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-command-args-override/terraform.tf
@@ -1,0 +1,9 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    kubernetes = {
+      version = ">= 2.11.0"
+    }
+  }
+}


### PR DESCRIPTION


This pull request related to task 077 create Pod and customize container command and args `easy-kubernetes-pod-container-command-args-override`
