### PR TITLE
add example:kubernetes easy-kubernetes-pod-container-exec-readiness-probe

### DIFF
--- a/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/main.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/main.tf
@@ -1,0 +1,26 @@
+# https://github.com/ssbostan/terraform-awesome
+
+resource "kubernetes_pod" "nginx" {
+  metadata {
+    name      = "nginx"
+    namespace = "default"
+    labels = {
+      "app.kubernetes.io/name"       = "nginx"
+      "app.kubernetes.io/created-by" = "terraform-awesome"
+    }
+  }
+  spec {
+    container {
+      name  = "nginx"
+      image = "nginx:alpine"
+      readiness_probe {
+        initial_delay_seconds = 3
+        period_seconds        = 10
+        failure_threshold     = 5
+        exec {
+          command = ["kill -0", "1"]
+        }
+      }
+    }
+  }
+}

--- a/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/providers.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/providers.tf
@@ -1,0 +1,6 @@
+# https://github.com/ssbostan/terraform-awesome
+
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "default"
+}

--- a/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/terraform.tf
+++ b/examples/kubernetes/easy-kubernetes-pod-container-exec-readiness-probe/terraform.tf
@@ -1,0 +1,9 @@
+# https://github.com/ssbostan/terraform-awesome
+
+terraform {
+  required_providers {
+    kubernetes = {
+      version = ">= 2.11.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request is related to task 089 create Pod with container exec readinessProbe `easy-kubernetes-pod-container-exec-readiness-probe`